### PR TITLE
fix issue #40 where boolean conversion for auto cleanup setting failed

### DIFF
--- a/NetLock-RMM-Web-Console/Classes/ScreenRecorder/AutoCleanupService.cs
+++ b/NetLock-RMM-Web-Console/Classes/ScreenRecorder/AutoCleanupService.cs
@@ -42,7 +42,8 @@ namespace NetLock_RMM_Web_Console.Classes.ScreenRecorder
                 Logging.Handler.Debug("Classes.ScreenRecorder.AutoCleanupService", "Task started at:", DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
                 Console.WriteLine("Classes.ScreenRecorder.AutoCleanupService -> Task started at: " + DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
 
-                bool isEnabled = Convert.ToBoolean(await MySQL.Handler.Quick_Reader("SELECT * FROM settings;", "remote_screen_session_recording_auto_clean_enabled"));
+                string isEnabledStr = await MySQL.Handler.Quick_Reader("SELECT * FROM settings;", "remote_screen_session_recording_auto_clean_enabled");
+                bool isEnabled = isEnabledStr == "1";
                 int daysToKeep = Convert.ToInt32(await MySQL.Handler.Quick_Reader("SELECT * FROM settings;", "remote_screen_session_recording_forced_days"));
 
                 Logging.Handler.Debug("Classes.ScreenRecorder.AutoCleanupService", "Auto cleanup enabled:", isEnabled.ToString());


### PR DESCRIPTION
This PR fixes a `FormatException` that occurred when reading the `remote_screen_session_recording_auto_clean_enabled` setting from MySQL.  
Previously, the code used `Convert.ToBoolean()` on a string value ("1"/"0").
`Convert.ToBoolean()` only accepts `"True"` or `"False"` (case-insensitive), or `"true"`/`"false"` as valid boolean strings.  
It does **not** accept `"1"` or `"0"` as valid input for booleans.
Now, the code checks if the value is `"1"` to determine if the setting is enabled.
