### PR TITLE
feat: Add copy file and folder name options to the remote file browser

### DIFF
--- a/NetLock-RMM-Web-Console/Components/Pages/Devices/Dialogs/Remote_File_Browser/File_Browser_Dialog.razor
+++ b/NetLock-RMM-Web-Console/Components/Pages/Devices/Dialogs/Remote_File_Browser/File_Browser_Dialog.razor
@@ -90,6 +90,7 @@
                                                 <MudMenuItem @onclick="async () => { await Remote_File_Browser_Delete_Directory(remote_file_browser_row.path); }">@Localizer["delete"]</MudMenuItem>
                                                 <MudMenuItem @onclick="async () => { await Remote_File_Browser_Move_Directory_Dialog(remote_file_browser_row.path); }">@Localizer["move"]</MudMenuItem>
                                                 <MudMenuItem @onclick="async () => { await Remote_File_Browser_Rename_Directory_Dialog(remote_file_browser_row.path); }">@Localizer["rename"]</MudMenuItem>
+                                                <MudMenuItem @onclick="async () => { await Remote_File_Browser_Copy_Full_Path(remote_file_browser_row.path); }">@Localizer["copy_full_path"]</MudMenuItem>
                                             }
                                             else
                                             {
@@ -97,6 +98,8 @@
                                                 <MudMenuItem @onclick="async () => { await Remote_File_Browser_Delete_File(remote_file_browser_row.path); }">@Localizer["delete"]</MudMenuItem>
                                                 <MudMenuItem @onclick="async () => { await Remote_File_Browser_Move_File_Dialog(remote_file_browser_row.path); }">@Localizer["move"]</MudMenuItem>
                                                 <MudMenuItem @onclick="async () => { await Remote_File_Browser_Rename_File_Dialog(remote_file_browser_row.path); }">@Localizer["rename"]</MudMenuItem>
+                                                <MudMenuItem @onclick="async () => { await Remote_File_Browser_Copy_Filename(remote_file_browser_row.name); }">@Localizer["copy_filename"]</MudMenuItem>
+                                                <MudMenuItem @onclick="async () => { await Remote_File_Browser_Copy_Full_Path(remote_file_browser_row.path); }">@Localizer["copy_full_path"]</MudMenuItem>
                                             }
                                         }
 
@@ -1864,6 +1867,26 @@
         }
 
         await Remote_File_Browser_Rename_File(_remote_file_path, _remote_file_path_new);
+    }
+
+    private async Task Remote_File_Browser_Copy_Filename(string filename)
+    {
+        Snackbar.Configuration.ShowCloseIcon = true;
+        Snackbar.Configuration.PositionClass = Defaults.Classes.Position.BottomRight;
+
+        await JSRuntime.InvokeVoidAsync("navigator.clipboard.writeText", filename);
+
+        Snackbar.Add(Localizer["copied_to_clipboard"], Severity.Info);
+    }
+
+    private async Task Remote_File_Browser_Copy_Full_Path(string path)
+    {
+        Snackbar.Configuration.ShowCloseIcon = true;
+        Snackbar.Configuration.PositionClass = Defaults.Classes.Position.BottomRight;
+
+        await JSRuntime.InvokeVoidAsync("navigator.clipboard.writeText", path);
+
+        Snackbar.Add(Localizer["copied_to_clipboard"], Severity.Info);
     }
 
     private bool uploading_linear = false;

--- a/NetLock-RMM-Web-Console/Resources/Components/Pages/Devices/Dialogs/Remote_File_Browser/File_Browser_Dialog.de-DE.resx
+++ b/NetLock-RMM-Web-Console/Resources/Components/Pages/Devices/Dialogs/Remote_File_Browser/File_Browser_Dialog.de-DE.resx
@@ -267,4 +267,10 @@
   <data name="wait_for_device_to_download_file" xml:space="preserve">
     <value>Warten auf das Herunterladen der Datei durch das Gerät.</value>
   </data>
+  <data name="copy_filename" xml:space="preserve">
+    <value>Dateiname kopieren</value>
+  </data>
+  <data name="copy_full_path" xml:space="preserve">
+    <value>Vollständigen pfad kopieren</value>
+  </data>
 </root>

--- a/NetLock-RMM-Web-Console/Resources/Components/Pages/Devices/Dialogs/Remote_File_Browser/File_Browser_Dialog.en-US.resx
+++ b/NetLock-RMM-Web-Console/Resources/Components/Pages/Devices/Dialogs/Remote_File_Browser/File_Browser_Dialog.en-US.resx
@@ -267,4 +267,10 @@
   <data name="wait_for_device_to_download_file" xml:space="preserve">
     <value>Wait for the device to download the file.</value>
   </data>
+  <data name="copy_filename" xml:space="preserve">
+    <value>Copy filename</value>
+  </data>
+  <data name="copy_full_path" xml:space="preserve">
+    <value>Copy full path</value>
+  </data>
 </root>


### PR DESCRIPTION
- Add right-click menu items for copying filename and full path
- Includes German and English translations

See also ticket #75 for more information.

_**WARNING: this implementation has not been tested!**_