### PR TITLE
Fixed bug with $mysql_password not being correctly escaped when generating docker-composer.yml

### DIFF
--- a/docker-compose-quick-setup.sh
+++ b/docker-compose-quick-setup.sh
@@ -624,7 +624,7 @@ services:
     image: mysql:8.0
     container_name: mysql8-container
     environment:
-      MYSQL_ROOT_PASSWORD: $mysql_password
+      MYSQL_ROOT_PASSWORD: "$mysql_password"
       MYSQL_DATABASE: netlock
     volumes:
       - /home/netlock/mysql/data:/var/lib/mysql


### PR DESCRIPTION
Fixes this bug when generating docker-composer.yml with docker-compose-quick-setup.sh:
If you use an special character in the MySQL password, it will probably fail as the string is not limited by double quotes.