### PR TITLE
 Improve Docker deployment script

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(mv:*)"
+    ],
+    "deny": []
+  }
+}

--- a/NetLock-docker-quick-deployment/02_update-ssl-certificates.sh
+++ b/NetLock-docker-quick-deployment/02_update-ssl-certificates.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Configuration
+DEPLOYMENT_DIR="${1:-/opt/netlockrmm}"
+WEB_CONSOLE_APPSETTINGS="$DEPLOYMENT_DIR/web_console/appsettings.json"
+SERVER_APPSETTINGS="$DEPLOYMENT_DIR/server/appsettings.json"
+CERT_DIR="$DEPLOYMENT_DIR/letsencrypt/certs"
+
+echo "Waiting 30 seconds for containers to start and Let's Encrypt to generate certificate..."
+sleep 30
+
+echo "Looking for Let's Encrypt certificate in $CERT_DIR..."
+
+# Wait up to 5 minutes for certificate to appear
+TIMEOUT=300  # 5 minutes
+ELAPSED=0
+INTERVAL=15
+
+while [ $ELAPSED -lt $TIMEOUT ]; do
+    # Find the first .pfx file
+    CERT_FILE=$(find "$CERT_DIR" -name "*.pfx" -type f | head -1)
+    
+    if [ -n "$CERT_FILE" ]; then
+        echo "Certificate found: $(basename "$CERT_FILE")"
+        
+        # Update both appsettings.json files with the actual certificate path
+        CERT_FILENAME=$(basename "$CERT_FILE")
+        NEW_CERT_PATH="/app/letsencrypt/certs/$CERT_FILENAME"
+        
+        echo "Updating certificate path in both appsettings files..."
+        
+        # Create backups
+        cp "$WEB_CONSOLE_APPSETTINGS" "$WEB_CONSOLE_APPSETTINGS.backup"
+        cp "$SERVER_APPSETTINGS" "$SERVER_APPSETTINGS.backup"
+        
+        # Replace the certificate path in web console appsettings
+        echo "Updating web console appsettings.json..."
+        sed -i "s|\"Path\": \"/app/letsencrypt/certs/certificate.pfx\"|\"Path\": \"$NEW_CERT_PATH\"|g" "$WEB_CONSOLE_APPSETTINGS"
+        WEB_CONSOLE_UPDATE=$?
+        
+        # Replace the certificate path in server appsettings  
+        echo "Updating server appsettings.json..."
+        sed -i "s|\"Path\": \"/path/to/certificates/certificate.pfx\"|\"Path\": \"$NEW_CERT_PATH\"|g" "$SERVER_APPSETTINGS"
+        SERVER_UPDATE=$?
+        
+        if [ $WEB_CONSOLE_UPDATE -eq 0 ] && [ $SERVER_UPDATE -eq 0 ]; then
+            echo "Certificate path updated successfully in both files to: $NEW_CERT_PATH"
+            
+            # Restart both containers to pick up the new certificate path
+            echo "Restarting containers..."
+            docker compose -f "$DEPLOYMENT_DIR/docker-compose.yml" restart netlock-web-console netlock-rmm-server
+            
+            echo "Certificate configuration completed!"
+            exit 0
+        else
+            echo "Error: Failed to update one or both appsettings.json files"
+            echo "Web console update result: $WEB_CONSOLE_UPDATE"
+            echo "Server update result: $SERVER_UPDATE"
+            exit 1
+        fi
+    fi
+    
+    echo "Certificate not found yet, waiting $INTERVAL more seconds... ($(((TIMEOUT-ELAPSED)/60)) minutes remaining)"
+    sleep $INTERVAL
+    ELAPSED=$((ELAPSED + INTERVAL))
+done
+
+echo "Timeout: Certificate was not generated within $((TIMEOUT/60)) minutes"
+echo "Please check the containers logs:"
+echo "  docker logs netlock-web-console"
+echo "  docker logs netlock-rmm-server"
+exit 1

--- a/NetLock-docker-quick-deployment/template_docker-compose.yml
+++ b/NetLock-docker-quick-deployment/template_docker-compose.yml
@@ -1,0 +1,51 @@
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: mysql8-container
+    environment:
+      MYSQL_ROOT_PASSWORD: ${mysql_password}
+      MYSQL_DATABASE: netlock
+    volumes:
+      - ./mysql/data:/var/lib/mysql
+      - /etc/localtime:/etc/localtime:ro
+    networks:
+      - netlock-network
+    restart: always
+    command: --skip-log-bin
+
+  netlock-web-console:
+    image: nicomak101/netlock-rmm-web-console:latest
+    container_name: netlock-web-console
+    environment:
+      - TZ=${timezone}
+    volumes:
+      - "./web_console/appsettings.json:/app/appsettings.json"
+      - "./web_console/internal:/app/internal"
+      - "./web_console/logs:/var/0x101 Cyber Security/NetLock RMM/Web Console/"
+      - "./letsencrypt:/app/letsencrypt"
+      - /etc/localtime:/etc/localtime:ro
+    ports:${web_console_docker_ports}
+    networks:
+      - netlock-network
+    restart: always
+
+  netlock-rmm-server:
+    image: nicomak101/netlock-rmm-server:latest
+    container_name: netlock-rmm-server
+    environment:
+      - TZ=${timezone}
+    volumes:
+      - "./server/appsettings.json:/app/appsettings.json"
+      - "./server/internal:/app/internal"
+      - "./server/files:/app/www/private/files"
+      - "./server/logs:/var/0x101 Cyber Security/NetLock RMM/Server/"
+      - "./letsencrypt:/app/letsencrypt"
+      - /etc/localtime:/etc/localtime:ro
+    ports:${server_docker_ports}
+    networks:
+      - netlock-network
+    restart: always
+
+networks:
+  netlock-network:
+    driver: bridge

--- a/NetLock-docker-quick-deployment/template_server-appsettings.json
+++ b/NetLock-docker-quick-deployment/template_server-appsettings.json
@@ -1,0 +1,70 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft": "Error",
+      "Microsoft.Hosting.Lifetime": "Warning",
+      "Microsoft.AspNetCore.SignalR": "Error",
+      "Microsoft.AspNetCore.Http.Connections": "Error"
+    },
+    "Custom": {
+      "Enabled": false
+    }
+  },
+  "AllowedHosts": "*",
+  "Kestrel": {
+    "Endpoint": {
+      "Http": {
+        "Enabled": ${server_http_enabled},
+        "Port": ${server_port_http}
+      },
+      "Https": {
+        "Enabled": ${server_https_enabled},
+        "Port": ${server_port_https},
+        "Force": ${server_https_forced},
+        "Hsts": {
+          "Enabled": true
+        },
+        "Certificate": {
+          "Path": "/path/to/certificates/certificate.pfx",
+          "Password": "${le_pfx_password}"
+        }
+      }
+    },
+    "Roles": {
+      "Comm": true,
+      "Update": true,
+      "Trust": true,
+      "Remote": true,
+      "Notification": true,
+      "File": true,
+      "LLM": true
+    }
+  },
+  "MySQL": {
+    "Server": "mysql8-container",
+    "Port": 3306,
+    "Database": "netlock",
+    "User": "root",
+    "Password": "${mysql_password}",
+    "SslMode": "None",
+    "AdditionalConnectionParameters": "AllowPublicKeyRetrieval=True;"
+  },
+  "LettuceEncrypt": {
+    "Enabled": ${le_enabled},
+    "AcceptTermsOfService": true,
+    "DomainNames": [
+      "${server_domain}"
+    ],
+    "EmailAddress": "${le_email}",
+    "AllowedChallengeTypes": "Http01",
+    "CertificateStoredPfxPassword": "${le_pfx_password}"
+  },
+  "Members_Portal_Api": {
+    "Enabled": true,
+    "ApiKeyOverride": "${apiKeyOverride}"
+  },
+  "Environment": {
+    "Docker": true
+  }
+}

--- a/NetLock-docker-quick-deployment/template_web-console-appsettings.json
+++ b/NetLock-docker-quick-deployment/template_web-console-appsettings.json
@@ -1,0 +1,75 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft": "Error",
+      "Microsoft.Hosting.Lifetime": "Warning"
+    },
+    "Custom": {
+      "Enabled": true
+    }
+  },
+  "AllowedHosts": "*",
+  "Kestrel": {
+    "Endpoint": {
+      "Http": {
+        "Enabled": ${web_console_http_enabled},
+        "Port": ${web_console_port_http}
+      },
+      "Https": {
+        "Enabled": ${web_console_https_enabled},
+        "Port": ${web_console_port_https},
+        "Force": true,
+        "Hsts": {
+          "Enabled": true
+        },
+        "Certificate": {
+          "Path": "${web_console_cert_path}",
+          "Password": "${le_pfx_password}"
+        }
+      }
+    },
+    "IpWhitelist": ${ip_whitelist_json},
+    "KnownProxies": ${known_proxies_json}
+  },
+  "NetLock_Remote_Server": {
+    "Server": "${web_console_server_host}",
+    "Port": ${web_console_server_port},
+    "UseSSL": ${web_console_server_ssl}
+  },
+  "NetLock_File_Server": {
+    "Server": "${web_console_server_host}",
+    "Port": ${web_console_server_port},
+    "UseSSL": ${web_console_server_ssl}
+  },
+  "MySQL": {
+    "Server": "mysql8-container",
+    "Port": 3306,
+    "Database": "netlock",
+    "User": "root",
+    "Password": "${mysql_password}",
+    "SslMode": "None",
+    "AdditionalConnectionParameters": "AllowPublicKeyRetrieval=True;"
+  },
+  "LettuceEncrypt": {
+    "Enabled": ${le_enabled},
+    "AcceptTermsOfService": true,
+    "DomainNames": [
+      "${web_console_domain}", "${server_domain}"
+    ],
+    "EmailAddress": "${le_email}",
+    "AllowedChallengeTypes": "Http01",
+    "CertificateStoredPfxPassword": "${le_pfx_password}"
+  },
+  "Webinterface": {
+    "Title": "${web_console_title}",
+    "Language": "en-US",
+    "Membership_Reminder": true,
+    "PublicOverrideUrl": "${publicOverrideUrl}"
+  },
+  "Members_Portal_Api": {
+    "Enabled": true,
+    "Cloud": false,
+    "ApiKeyOverride": "${apiKeyOverride}"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -82,24 +82,29 @@ Do you wish to get started as fast as possible? Our docker compose script ensure
 - Reverse Proxy (supports any reverse proxy)
 - Local Testing (only for local test environments, not for production)
 
-The script expects docker compose to be installed, on a linux disctribution. Best to use would be Ubuntu 24.04. The script deploys the NetLock RMM componments as well as a MySQL 8.0 server and connects everything with each other.
+The script expects docker compose to be installed, on a linux distribution. Best to use would be Ubuntu 24.04. The script deploys the NetLock RMM components as well as a MySQL 8.0 server and connects everything with each other.
 
-1. Download the script with wget.
-```plaintext
-sudo wget -P /home https://raw.githubusercontent.com/0x101-Cyber-Security/NetLock-RMM/main/docker-compose-quick-setup.sh
+1. Clone the repository (latest commit only):
+```bash
+git clone --depth 1 https://github.com/0x101-Cyber-Security/NetLock-RMM.git
 ```
 
-2. Make it executable:
-```plaintext
-sudo chmod +x /home/docker-compose-quick-setup.sh
+2. Navigate to the Docker deployment directory:
+```bash
+cd NetLock-RMM/NetLock-docker-quick-deployment
 ```
 
-3. Execute it:
-```plaintext
-sudo ./home/docker-compose-quick-setup.sh
+3. Make the scripts executable (if necessary):
+```bash
+chmod +x 01_quick-install.sh 02_update-ssl-certificates.sh
 ```
 
-4. Follow the instructions.
+4. Execute the setup script:
+```bash
+sudo ./01_quick-install.sh
+```
+
+5. Follow the instructions in the script.
 
 ## Video Tutorial
 [Watch the video on YouTube](https://youtu.be/-VMoL6wnSKs)


### PR DESCRIPTION
 Hi! I've been testing your software and encountered some
  challenges during the initial setup process. I'd like to
  contribute by improving the quick setup script - here's my Pull
  Request.

  ## Changes Made:

  I've enhanced the script to properly configure domains and ports
  in appsettings.json based on the chosen deployment scenario
  (direct access, reverse proxy, or lab environment without HTTPS).

  Additionally, I've implemented several security and usability
  improvements:

  - Modified Docker port exposure to bind to 127.0.0.1 instead of
  all interfaces for reverse proxy deployments, preventing direct
  internet access on VPS services without security groups
  - Removed MySQL port exposure as external access isn't required
  - Changed the default installation directory to /opt/netlockrmm
  for better system organization
  - Replaced hardcoded paths in docker-compose with relative paths
  for improved portability

  ## Summary:
  - Ensure domains and ports in appsettings.json are configured
  according to deployment type
  - Update README with new installation steps using
  NetLock-docker-quick-deployment/
  - Streamline setup process to make NetLock RMM immediately ready
  for use after deployment